### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on: push
 
 name: Continuous integration
+permissions:
+  contents: read
 
 jobs:
   ci:


### PR DESCRIPTION
Potential fix for [https://github.com/gilescope/atoi_radix10/security/code-scanning/6](https://github.com/gilescope/atoi_radix10/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not perform any write operations, we can set the permissions to `contents: read` at the root level of the workflow. This will apply to all jobs unless overridden by a job-specific `permissions` block.

The changes should be made at the top level of the workflow file, immediately after the `name` field, to ensure that all jobs inherit the restricted permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration for improved permissions management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->